### PR TITLE
Allow manual defined? checks

### DIFF
--- a/lib/aye_var.rb
+++ b/lib/aye_var.rb
@@ -61,6 +61,14 @@ module AyeVar
 			new_context(node) { super }
 		end
 
+		def visit_defined_node(node)
+			if Prism::InstanceVariableReadNode === node.value
+				context << node.value.name
+			end
+
+			super
+		end
+
 		def visit_def_node(node)
 			parent = @this
 

--- a/test/example.rb
+++ b/test/example.rb
@@ -30,4 +30,12 @@ class Example
 	def bar=(value)
 		@bar = value
 	end
+
+	def lazy
+		if defined?(@lazy)
+			@lazy
+		else
+			@lazy = 1
+		end
+	end
 end


### PR DESCRIPTION
In cases where you manually check if an instance variable is defined, I think you’ve established that you know what instance variable you’re talking about and that it may not yet be defined. In these cases, I think it should be allowable to assign the instance variable.

If you do use it, you’ve already written it at least twice, thus reducing the chances of a typo. But more importantly, you are likely expecting it to be undefined and intentionally handling that scenario.

Example:

```ruby
def lazy
  if defined?(@lazy)
    @lazy
  else
    @lazy = 1
  end
end
```