### PR TITLE
Allow ivar definitions anywhere

### DIFF
--- a/test/aye_var.test.rb
+++ b/test/aye_var.test.rb
@@ -6,32 +6,14 @@ require_relative "example"
 
 example = Example.new
 
-test "undefined write in singleton" do
-	refute_raises do
-		assert_equal 1, Example.bar
-	end
-end
-
 test "undefined read" do
 	assert_raises AyeVar::NameError do
 		assert example.foo
 	end
 end
 
-test "undefined write" do
-	assert_raises AyeVar::NameError do
-		assert example.foo = 1
-	end
-end
-
 test "defined read" do
 	refute_raises do
 		assert_equal "bar", example.bar
-	end
-end
-
-test "defined write" do
-	refute_raises do
-		assert_equal 1, example.bar = 1
 	end
 end

--- a/test/example.rb
+++ b/test/example.rb
@@ -1,41 +1,15 @@
 # frozen_string_literal: true
 
 class Example
-	class << self
-		def foo
-			@foo = 1
-		end
-	end
-
 	def initialize
 		@bar = "bar"
 	end
 
-	def self.bar
-		@bar = 1
-	end
-
 	def foo
-		@foo = 1
-	end
-
-	def foo=(value)
-		@foo = value
+		@foo
 	end
 
 	def bar
 		@bar
-	end
-
-	def bar=(value)
-		@bar = value
-	end
-
-	def lazy
-		if defined?(@lazy)
-			@lazy
-		else
-			@lazy = 1
-		end
 	end
 end


### PR DESCRIPTION
This PR makes it possible to define undefined instance variables in any context by assigning a value. Previously, you could not assign instance variables in an instance method unless it was `initialize` or `setup`.